### PR TITLE
fix bug where modelling interface is cut on right side

### DIFF
--- a/client/src/components/content/BpmnModeler/BpmnModeler.jsx
+++ b/client/src/components/content/BpmnModeler/BpmnModeler.jsx
@@ -32,9 +32,6 @@ class BpmnModelerComponent extends Component {
       keyboard: {
         bindTo: window,
       },
-      propertiesPanel: {
-        parent: '#propview',
-      },
       additionalModules: [propertiesProviderModule],
       moddleExtensions: {
         camunda: camundaModdleDescriptor,
@@ -119,7 +116,7 @@ class BpmnModelerComponent extends Component {
           <div id='bpmncontainer'>
             <div
               id='bpmnview'
-              style={{ width: '85%', height: '98vh', float: 'left' }}
+              style={{ width: '100%', height: '98vh', float: 'left' }}
             ></div>
           </div>
         </Content>


### PR DESCRIPTION
fixes #75 

## Changes

The modelling interface was cut short on the right side, so that there was a gap between the modeller and the properties panel we built. 
- I removed the value of the width of the modelling canvas being set to 85% and set it to 100%. Now it goes the full width and even behind our properties panel, which allows for a more natural look and feel and allows for the full page being used once we decide in the future to only show the side panel one an activity has been selected.
- I also removed unnecessary code related to the original sidebar

## Screenshots
![grafik](https://user-images.githubusercontent.com/44369294/106441054-dd352480-6479-11eb-91be-adb72ba84507.png)



## Checklist before merge

**Developer's responsibilities**
* [X] **Assign** one or two developers
* [ ] **Change code** if reviewer(s) has/have requested it
* [ ] **Pull request build** has passed
* [X] **tested locally** (in at least chrome & firefox if frontend)
