### PR TITLE
edited SSOT

### DIFF
--- a/wiki/SSoT-deutsch.md
+++ b/wiki/SSoT-deutsch.md
@@ -189,8 +189,8 @@ Hierbei ändert sich nichts im Vergleich zu Daniels Aufschlag einer SSoT. Nutzer
 ```json
 {
   "type": "MARKER",
-  "id": "exampleId",
   "name": "5 Sekunden warten",
+  "id": "exampleId",
   "predecessorIds": ["randomId"],
   "successorIds": ["randomId"]
 }
@@ -510,8 +510,8 @@ Modellierter Prozess
     "elements": [
         {
             "type": "MARKER",
-            "id": "StartEvent_1",
             "name": "",
+            "id": "StartEvent_1",
             "predecessorIds": [],
             "successorIds": ["Activity_0a128t6"],
         },
@@ -583,8 +583,8 @@ Modellierter Prozess
         // Endevent
         {
             "type": "MARKER",
-            "id": "Event_0wghmrz",
             "name": "",
+            "id": "Event_0wghmrz",
             "predecessorIds": ["Activity_0a128t6"],
             "successorIds": [],
         }

--- a/wiki/SSoT-deutsch.md
+++ b/wiki/SSoT-deutsch.md
@@ -522,9 +522,6 @@ Modellierter Prozess
             "id": "Activity_0a128t6",
             "predecessorIds": ["StartEvent_1"],
             "successorIds": ["Activity_0ascvdr"],
-            "rpaApplication": "",
-            "rpaTask": "",
-            "rpaParameters": [],
             "outputVariable": ""
         },
         // RPA activity


### PR DESCRIPTION
I aplied some changes to the SSOT example that were inconsistent with the definitions above:
- Switched the Id and Name positions for Marker elements
- I removed unused RPA filed form non RPA Instructions

Please also see the discussion below regarding the OutputVariable Field
