### PR TITLE
fixes deployment shallow copy issue

### DIFF
--- a/.github/workflows/heroku_deploy.yml
+++ b/.github/workflows/heroku_deploy.yml
@@ -9,13 +9,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: copy server to root and commit
-        run: mv ./server/* ./
-      - run: git config user.email "heroku.deployer@ark-automate.com" && git config user.name "Heroku Deployer" && git add -A && git commit -m "heroku deployment commit"
+        with:
+          fetch-depth: 0
+      - name: build client; do dir magic
+        run: |
+          cd client/ && npm install && CI=false npm run build
+          cd ..
+          mv ./client/build ./
+          rm -r client
+          mv ./server/* ./
       - uses: akhileshns/heroku-deploy@v3.11.10
         with:
           heroku_api_key: ${{secrets.HEROKU_API_KEY}}
           heroku_app_name: "ark-automate"
           heroku_email: ${{secrets.HEROKU_EMAIL}}
           justlogin: true
-      - run: heroku git:remote -a ark-automate && git push heroku DEV:master --force
+      - run: heroku git:remote -a ark-automate
+      - run: git config user.email "heroku.deployer@ark-automate.com" && git config user.name "Heroku Deployer" && git add . && git commit -m "heroku deployment commit"
+      - run: git push heroku master --force

--- a/client/package.json
+++ b/client/package.json
@@ -2,6 +2,7 @@
   "name": "ark-automate",
   "version": "0.1.0",
   "private": true,
+  "homepage": ".",
   "proxy": "http://localhost:5000/",
   "dependencies": {
     "@craco/craco": "^6.1.1",

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "start": "node server",
-    "build": "cd client/ && npm install && npm run build",
+    "build": "",
     "test": "jest",
     "lint": "eslint --ignore-path ../.gitignore --ext .js,.jsx ."
   },

--- a/server/server.js
+++ b/server/server.js
@@ -29,15 +29,15 @@ if (!isDev && cluster.isMaster) {
   mongoose.connect(process.env.MONGODB_URI, { useNewUrlParser: true, useUnifiedTopology: true });
 
   // Priority serve any static files.
-  app.use(express.static(path.resolve(__dirname, 'client/build')));
+  app.use(express.static(path.resolve(__dirname, 'build')));
   app.use(express.json());
 
   app.use('/rpa-framework', rpaFrameworkRouter);
   app.use('/ssot', ssotRouter);
 
   // All remaining requests return the React app, so it can handle routing.
-  app.get('*', function (request, response) {
-    response.sendFile(path.resolve(__dirname, 'client/build', 'index.html'));
+  app.get('*', (request, response) => {
+    response.sendFile(path.resolve(__dirname, 'build', 'index.html'));
   }); 
 
   app.listen(PORT, () => {


### PR DESCRIPTION
fixes #12 

The current version of the deployment failed because it was perceived as a shallow copy to heroku. Now we have a workaround for this and also have new directory magic to correctly display the right content
