### PR TITLE
rename robot functionality

### DIFF
--- a/client/src/api/SSOTretrieval.js
+++ b/client/src/api/SSOTretrieval.js
@@ -13,4 +13,18 @@
     return response;
   };
 
-export default fetchSSOTsForUser;
+  /**
+   * @description Fetch all those SSOT names and Ids, which are available for the current user
+   * @param {String} userId - String including the user Id
+   */
+   const changeSSOTName = async (SSOTid, newName) => {
+      const adjustedName = newName.replace(/\s/g, '+');
+      const requestString = `/ssot/renameBot?id=${ SSOTid }&newName=${ adjustedName }`;
+      const response = await fetch(requestString);
+      return response;
+    };
+
+export {
+  fetchSSOTsForUser,
+  changeSSOTName
+};

--- a/client/src/components/content/RobotContainer/RobotContainer.jsx
+++ b/client/src/components/content/RobotContainer/RobotContainer.jsx
@@ -1,9 +1,10 @@
 /* eslint-disable no-alert */
-import React from 'react';
+import React, { useState } from 'react';
 import { Col, Row, Typography } from 'antd';
 import { PlayCircleOutlined, EditOutlined } from '@ant-design/icons';
 import PropTypes from 'prop-types'
 import styles from './RobotContainer.module.css';
+import {changeSSOTName} from '../../../api/SSOTretrieval';
 
 const { Title } = Typography;
 
@@ -14,9 +15,21 @@ const { Title } = Typography;
  */
 const RobotContainer = (props) => {
 
-    const { robotName } = props;
+    const {robotId} = props;
+    // eslint-disable-next-line react/destructuring-assignment
+    const [robotName, setRobotName] = useState(props.robotName);
     const startRobot = () => alert("Running the Robot is currently not supported!");
     const editRobot = () => alert("Editing the Robot is currently not supported!");
+
+    const renameRobot = (value) => {
+        changeSSOTName(robotId, value)
+            .then(() => {
+                setRobotName(value);
+            })
+            .catch((error) => {
+                console.error(error);
+            });
+    }
 
     return (
         <Col xs={24} sm={12} md={8} xl={6} xxl={4}>
@@ -31,7 +44,7 @@ const RobotContainer = (props) => {
                 </Row>
 
                 <Row justify="space-around" align="middle" style={{ height: '45%' }}>
-                    <Title className={styles.title} level={3} editable >
+                    <Title className={styles.title} level={3} editable={{ onChange: renameRobot }} >
                         {robotName}
                     </Title>
                 </Row>
@@ -43,4 +56,5 @@ export default RobotContainer;
 
 RobotContainer.propTypes = {
     robotName: PropTypes.string.isRequired,
+    robotId: PropTypes.string.isRequired,
 };

--- a/client/src/components/pages/RobotOverview/RobotOverview.jsx
+++ b/client/src/components/pages/RobotOverview/RobotOverview.jsx
@@ -4,7 +4,7 @@ import HeaderNavbar from '../../content/HeaderNavbar/HeaderNavbar';
 import RobotContainer from '../../content/RobotContainer/RobotContainer';
 import CreateRobotContainer from '../../content/RobotContainer/CreateRobotContainer';
 import initSessionStorage from '../../../utils/sessionStorage';
-import fetchSSOTsForUser from '../../../api/SSOTretrieval';
+import {fetchSSOTsForUser} from '../../../api/SSOTretrieval';
 
 const { Search } = Input;
 const { Option } = Select;
@@ -21,10 +21,10 @@ const RobotOverview = () => {
 
   /**
    * @description Fetches Bots for the specified user and will trigger a rerender so that it will be displayed
-   * @param {String} userIuserIdToFetch The userId to fetch Bots for
+   * @param {String} userIdToFetch The userId to fetch Bots for
    */
-   const retrieveBotList = (userIuserIdToFetch) => {
-    fetchSSOTsForUser(userIuserIdToFetch)
+   const retrieveBotList = (userIdToFetch) => {
+    fetchSSOTsForUser(userIdToFetch)
       .then((response) => response.json())
       .then((data) => {
         setRobotList(data);
@@ -75,7 +75,10 @@ const RobotOverview = () => {
     return (
       <>
         {filteredBotList.map((val) => (
-          <RobotContainer robotName={val.robotName} />
+          <RobotContainer 
+            robotId={val.robotId} 
+            robotName={val.robotName} 
+          />
         ))}
       </>
     );

--- a/server/controllers/ssotRetrievalController.js
+++ b/server/controllers/ssotRetrievalController.js
@@ -54,3 +54,26 @@ exports.getBotList = async (req, res) => {
         console.error(err);
     }
 };
+
+// GET /renameBot?id=Browser&newName=Open+Browser
+exports.renameBot = async (req, res) => {
+    try {
+        res.set('Content-Type', 'application/json');
+        const {id} = req.query;
+        const {newName} = req.query;
+        const newNameWithEmptyspace = newName.replace(/\+/g, ' ');
+
+        const ssot = await mongoose.model('SSoT').findByIdAndUpdate(
+            { _id: id },
+            {'robotMetadata.robotName': newNameWithEmptyspace},
+            {
+                new: true,
+                useFindAndModify: false
+            }
+        ).exec();
+
+        res.send(ssot.robotMetadata);
+    } catch (err) {
+        console.error(err);
+    }
+};

--- a/server/routes/ssot.js
+++ b/server/routes/ssot.js
@@ -11,5 +11,6 @@ const retrievalController = require('../controllers/ssotRetrievalController');
 router.get('/parser/get-robot-code', parsingController.getRobotCode);
 router.get('/get/:id', retrievalController.getSingleSourceOfTruth);
 router.get('/getAvailableBotsForUser/:userid', retrievalController.getBotList);
+router.get('/renameBot', retrievalController.renameBot);
 
 module.exports = router;


### PR DESCRIPTION
The displayed bots are now able to be renamed.
closes #110 

## Screenshots
https://user-images.githubusercontent.com/36270527/110497534-d2178900-80f6-11eb-9b9d-55224fee92fe.mov

## Checklist before merge

**Developer's responsibilities**
* [ ] **Assign** one or two developers
* [ ] **Change code** if reviewer(s) has/have requested it
* [ ] **Pull request build** has passed
* [ ] **tested locally** (in at least chrome & firefox if frontend)
* [ ] updated the **documentation**
* [ ] added **tests** where necessary
