### PR TITLE
Implemented task reset

### DIFF
--- a/client/src/components/content/PropertiesPanel/PropertiesPanel.jsx
+++ b/client/src/components/content/PropertiesPanel/PropertiesPanel.jsx
@@ -164,6 +164,7 @@ const PropertiesPanel = ({ modeler }) => {
       currentElement: elementState.currentElement,
     });
     setSelectedApplication(value);
+    resetTask();
     getTasksForApplication(value);
   };
 
@@ -180,6 +181,18 @@ const PropertiesPanel = ({ modeler }) => {
       modeling,
       elementState.currentElement
     );
+  };
+
+  /**
+   * @description Gets called when a new app was selected in the dropwdown in the sidebar. Resets the task to default value
+   */
+  const resetTask = () => {
+    elementState.currentElement.businessObject.$attrs['arkRPA:task'] =
+      'Please select task';
+    setElementState({
+      selectedElements: elementState.selectedElements,
+      currentElement: elementState.currentElement,
+    });
   };
 
   return (

--- a/client/src/components/content/PropertiesPanel/PropertiesPanel.jsx
+++ b/client/src/components/content/PropertiesPanel/PropertiesPanel.jsx
@@ -184,7 +184,7 @@ const PropertiesPanel = ({ modeler }) => {
   };
 
   /**
-   * @description Gets called when a new app was selected in the dropwdown in the sidebar. Resets the task to default value
+   * @description Gets called when a new application was selected in the dropwdown in the sidebar. Resets the task to default value
    */
   const resetTask = () => {
     elementState.currentElement.businessObject.$attrs['arkRPA:task'] =

--- a/client/src/components/content/PropertiesPanel/PropertiesPanelTaskDropdown/PropertiesPanelTaskDropdown.jsx
+++ b/client/src/components/content/PropertiesPanel/PropertiesPanelTaskDropdown/PropertiesPanelTaskDropdown.jsx
@@ -24,6 +24,7 @@ const PropertiesPanelTaskDropdown = ({
       onChange={onTaskSelection}
       disabled={disabled ? true : null}
       defaultValue={currentSelection}
+      value={currentSelection}
     >
       {listOfTasks.map((task) => (
         <Option key={task} value={task}>


### PR DESCRIPTION
Co-authored-by: WolfgangDaniel <daniel.woelki@outlook.de>

Fixes #152 

## Changes
With this PR the task is now automatically changed when changing the selected application of an activity.

*describe problem here*
The task selection used to remain  when selecting a new application.




## Screenshots

https://user-images.githubusercontent.com/38314662/110777577-8fbe8b00-8261-11eb-885a-a2fa849037c0.mp4


## Checklist before merge

**Developer's responsibilities**
* [ ] **Assign** one or two developers
* [ ] **Change code** if reviewer(s) has/have requested it
* [ ] **Pull request build** has passed
* [ ] **tested locally** (in at least chrome & firefox if frontend)
* [ ] updated the **documentation**
* [ ] added **tests** where necessary
