### PR TITLE
fix empty parameterObject bug

### DIFF
--- a/client/src/utils/attributeAndParamUtils.js
+++ b/client/src/utils/attributeAndParamUtils.js
@@ -143,7 +143,7 @@ const getParameterObject = (robotId, activityId) => {
             element.Task === task
         ));
 
-        if (matchingComboObject) {
+        if (matchingComboObject && matchingComboObject.inputVars.length && matchingParameterObject.rpaParameters.length) {
             // In the future there could be a need for a more advanced signature check, but fur the current use cases this should be sufficient
             const comboParameterLength = matchingComboObject.inputVars.length;
             const parameterObjectLength = matchingParameterObject.rpaParameters.length;
@@ -171,7 +171,7 @@ const getParameterObject = (robotId, activityId) => {
         ));
 
         const rpaParameters = [];
-        if (matchingComboObject) {
+        if (matchingComboObject && matchingComboObject.inputVars) {
             matchingComboObject.inputVars.forEach((element) => {
                 const elementCopy = element;
                 elementCopy.value = '';

--- a/server/models/rpaTaskModel.js
+++ b/server/models/rpaTaskModel.js
@@ -15,7 +15,7 @@ const rpaTaskSchema = new Schema({
   Task: String,
   Code: String,
   outputValue: Boolean,
-  InputVars: [rpaVariableSchema],
+  inputVars: [rpaVariableSchema],
   Output: rpaVariableSchema
 });
 


### PR DESCRIPTION
Rendering an empty parameter object was throwing an error. This bug has now been fixed.