### PR TITLE
18 display rpaf code

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4143,6 +4143,17 @@
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
     },
+    "clipboard": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.8.tgz",
+      "integrity": "sha512-Y6WO0unAIQp5bLmk1zdThRhgJt/x3ks6f30s3oE3H1mgIEU33XyQjEf8gsf6DxC7NPX8Y1SsNWjUjL/ywLnnbQ==",
+      "optional": true,
+      "requires": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
+    },
     "cliui": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -5181,6 +5192,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+      "optional": true
     },
     "depd": {
       "version": "1.1.2",
@@ -7201,6 +7218,15 @@
         "ignore": "^5.1.4",
         "merge2": "^1.3.0",
         "slash": "^3.0.0"
+      }
+    },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "optional": true,
+      "requires": {
+        "delegate": "^3.1.2"
       }
     },
     "graceful-fs": {
@@ -12148,6 +12174,14 @@
         "react-is": "^17.0.1"
       }
     },
+    "prismjs": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
+      "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
+      "requires": {
+        "clipboard": "^2.0.0"
+      }
+    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -13230,6 +13264,11 @@
         "workbox-webpack-plugin": "5.1.4"
       }
     },
+    "react-simple-code-editor": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/react-simple-code-editor/-/react-simple-code-editor-0.11.0.tgz",
+      "integrity": "sha512-xGfX7wAzspl113ocfKQAR8lWPhavGWHL3xSzNLeseDRHysT+jzRBi/ExdUqevSMos+7ZtdfeuBOXtgk9HTwsrw=="
+    },
     "read-pkg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
@@ -14195,6 +14234,12 @@
         "min-dom": "^3.1.0",
         "mitt": "^1.1.3"
       }
+    },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
+      "optional": true
     },
     "select-hose": {
       "version": "2.0.0",
@@ -15507,6 +15552,12 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
+    },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "optional": true
     },
     "tiny-invariant": {
       "version": "1.1.0",

--- a/client/package.json
+++ b/client/package.json
@@ -19,11 +19,13 @@
     "camunda-bpmn-moddle": "^4.4.1",
     "craco-antd": "^1.19.0",
     "craco-less": "^1.17.1",
+    "prismjs": "^1.23.0",
     "prop-types": "^15.7.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.0",
+    "react-simple-code-editor": "^0.11.0",
     "socket.io-client": "^4.0.0",
     "web-vitals": "^0.2.4",
     "xmljs2": "^1.0.0"

--- a/client/src/components/pages/RobotFile/RobotFile.jsx
+++ b/client/src/components/pages/RobotFile/RobotFile.jsx
@@ -1,11 +1,12 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect } from 'react';
 import { Layout, Button, Space, Row, Col } from 'antd';
 import Editor from 'react-simple-code-editor';
 import { highlight, languages } from 'prismjs/components/prism-core';
 import HeaderNavbar from '../../content/HeaderNavbar/HeaderNavbar';
 import 'prismjs/components/prism-robotframework';
-import getParsedRobotFile from "../../../api/ssot";
-import "prismjs/themes/prism.css";
+import getParsedRobotFile from '../../../api/ssot';
+import 'prismjs/themes/prism.css';
+import styles from './RobotFile.module.css';
 
 /**
  * @description View of the robot file
@@ -13,8 +14,10 @@ import "prismjs/themes/prism.css";
  * @component
  */
 const RobotFile = () => {
-  const [code, setCode] = useState('Please wait, your robot file is being loaded.');
-  
+  const [code, setCode] = useState(
+    'Please wait, your robot file is being loaded.'
+  );
+
   /**
    * @description Equivalent to ComponentDidMount in class based components
    */
@@ -29,7 +32,7 @@ const RobotFile = () => {
 
   /**
    * @description Gets called when the the button is pressed to save to the cloud.
-   * This function will retrieve the code from the editor, parse it to a ssot and write the 
+   * This function will retrieve the code from the editor, parse it to a ssot and write the
    * resulting ssot into the sessionStorage.
    */
   const onSaveToCloud = async () => {
@@ -40,31 +43,37 @@ const RobotFile = () => {
   };
 
   return (
-    <Layout >
+    <Layout>
       <HeaderNavbar selectedKey={3} />
-        <Row justify="center" width='100%'>
-          <Col xs={24} sm={24} md={20} xl={16}>
-            <Space direction='vertical' size='middle' style={{ padding: '1rem', width: '100%' }}>
-              <Button type='primary' onClick={onSaveToCloud} style={{ width: '100%' }}>
-                Save changes to cloud
-              </Button>
-              <Editor
-                value={code}
-                onValueChange={(newCode) => setCode(newCode)}
-                highlight={highlightCode => highlight(highlightCode, languages.robotframework)}
-                padding={'1rem'}
-                style={{
-                  fontFamily: '"Fira code", "Fira Mono", monospace',
-                  fontSize: 20,
-                  'background-color': '#FFFFFF'
-                }}
-                tabsize={4}
-              />
-            </Space>
-          </Col>
+      <Row justify='center' width='100%'>
+        <Col xs={24} sm={24} md={20}>
+          <Space
+            direction='vertical'
+            size='middle'
+            style={{ padding: '1rem', width: '100%' }}
+          >
+            <Button
+              type='primary'
+              onClick={onSaveToCloud}
+              style={{ width: '100%' }}
+            >
+              Save changes to cloud
+            </Button>
+            <Editor
+              value={code}
+              onValueChange={(newCode) => setCode(newCode)}
+              highlight={(highlightCode) =>
+                highlight(highlightCode, languages.robotframework)
+              }
+              padding='1rem'
+              className={styles.editor}
+              tabsize={4}
+            />
+          </Space>
+        </Col>
       </Row>
     </Layout>
   );
-}
+};
 
 export default RobotFile;

--- a/client/src/components/pages/RobotFile/RobotFile.jsx
+++ b/client/src/components/pages/RobotFile/RobotFile.jsx
@@ -1,21 +1,70 @@
-import React from 'react';
-import { Layout, Typography } from 'antd';
+import React, { useState, useEffect } from "react";
+import { Layout, Button, Space, Row, Col } from 'antd';
+import Editor from 'react-simple-code-editor';
+import { highlight, languages } from 'prismjs/components/prism-core';
 import HeaderNavbar from '../../content/HeaderNavbar/HeaderNavbar';
-
-const { Title } = Typography;
+import 'prismjs/components/prism-robotframework';
+import getParsedRobotFile from "../../../api/ssot";
+import "prismjs/themes/prism.css";
 
 /**
  * @description View of the robot file
  * @category Client
  * @component
  */
-const RobotFile = () => (
-  <Layout>
-    <HeaderNavbar selectedKey={3} />
-    <Title style={{ paddingLeft: '2rem', paddingTop: '2rem' }}>
-      In future versions, the Robot Framework code can also be edited directly here.
-    </Title>
-  </Layout>
-);
+const RobotFile = () => {
+  const [code, setCode] = useState('Please wait, your robot file is being loaded.');
+  
+  /**
+   * @description Equivalent to ComponentDidMount in class based components
+   */
+  useEffect(() => {
+    const robotId = JSON.parse(sessionStorage.getItem('robotId'));
+    getParsedRobotFile(robotId)
+      .then((response) => response.text())
+      .then((robotCode) => {
+        setCode(robotCode);
+      });
+  }, []);
+
+  /**
+   * @description Gets called when the the button is pressed to save to the cloud.
+   * This function will retrieve the code from the editor, parse it to a ssot and write the 
+   * resulting ssot into the sessionStorage.
+   */
+  const onSaveToCloud = async () => {
+    const robotId = JSON.parse(sessionStorage.getItem('robotId'));
+    console.log(robotId);
+    console.log(code);
+    //please parse here to ssot and upsert
+  };
+
+  return (
+    <Layout >
+      <HeaderNavbar selectedKey={3} />
+        <Row justify="center" width='100%'>
+          <Col xs={24} sm={24} md={20} xl={16}>
+            <Space direction='vertical' size='middle' style={{ padding: '1rem', width: '100%' }}>
+              <Button type='primary' onClick={onSaveToCloud} style={{ width: '100%' }}>
+                Save changes to cloud
+              </Button>
+              <Editor
+                value={code}
+                onValueChange={(newCode) => setCode(newCode)}
+                highlight={highlightCode => highlight(highlightCode, languages.robotframework)}
+                padding={'1rem'}
+                style={{
+                  fontFamily: '"Fira code", "Fira Mono", monospace',
+                  fontSize: 20,
+                  'background-color': '#FFFFFF'
+                }}
+                tabsize={4}
+              />
+            </Space>
+          </Col>
+      </Row>
+    </Layout>
+  );
+}
 
 export default RobotFile;

--- a/client/src/components/pages/RobotFile/RobotFile.jsx
+++ b/client/src/components/pages/RobotFile/RobotFile.jsx
@@ -36,10 +36,13 @@ const RobotFile = () => {
    * resulting ssot into the sessionStorage.
    */
   const onSaveToCloud = async () => {
+    // eslint-disable-next-line no-unused-vars
     const robotId = JSON.parse(sessionStorage.getItem('robotId'));
-    console.log(robotId);
-    console.log(code);
-    //please parse here to ssot and upsert
+
+    /**
+     * please parse here to ssot and upsert
+     * use the variables robotId and code for parsing.
+     */
   };
 
   return (

--- a/client/src/components/pages/RobotFile/RobotFile.module.css
+++ b/client/src/components/pages/RobotFile/RobotFile.module.css
@@ -1,0 +1,5 @@
+.editor {
+  font-family: Consolas, monospace;
+  font-size: 1.25rem;
+  background-color: var(--colorBackground2);
+}


### PR DESCRIPTION
closes #18

## Changes
upon switching to the robot file tab in the web app there now is a code editor present which displays the code generated from the ssot in the database. 
Additionally there is a button to save changes to the cloud which can be used in the future to parse the code and upset it into the database. Currently the method for this already exists, but will only log the robotId and code to the console to display whoever is working on the #190 which variables can be used and where it should be implemented.

## Screenshots
<img width="1401" alt="image" src="https://user-images.githubusercontent.com/44369294/112945278-5ed0c800-9134-11eb-8fcf-113915adbef6.png">



## Checklist before merge

**Developer's responsibilities**
* [ ] **Assign** one or two developers
* [ ] **Change code** if reviewer(s) has/have requested it
* [ ] **Pull request build** has passed
* [ ] **tested locally** (in at least chrome & firefox if frontend)
* [ ] updated the **documentation**
* [ ] added **tests** where necessary
