### PR TITLE
parameterName display; upsert feedback

### DIFF
--- a/client/src/components/content/ModelerSidebar/ModelerSidebar.jsx
+++ b/client/src/components/content/ModelerSidebar/ModelerSidebar.jsx
@@ -1,7 +1,8 @@
 /* eslint-disable react/jsx-no-bind */
 import React, { useState, useEffect } from 'react';
-import { Typography, Layout, Space, Button } from 'antd';
+import { Typography, Layout, Space, Button, notification } from 'antd';
 import PropTypes from 'prop-types';
+import { CloudUploadOutlined } from '@ant-design/icons';
 import PropertiesPanel from './PropertiesPanel/PropertiesPanel';
 import styles from './ModelerSidebar.module.css';
 import { fetchTasksFromDB } from '../../../api/applicationAndTaskSelection';
@@ -17,6 +18,7 @@ import {
 } from '../../../utils/attributeAndParamUtils';
 import parseSsotToBpmn from '../../../utils/ssotToBpmnParsing/ssotToBpmnParsing';
 import { parseBpmnToSsot } from '../../../utils/BpmnToSsotParsing/BpmnToSsotParsing';
+import corporateDesign from '../../../layout/corporateDesign';
 
 const { Title } = Typography;
 const { Sider } = Layout;
@@ -246,6 +248,18 @@ const ModelerSidebar = ({ modeler, robotId }) => {
           sessionStorage.setItem('ssotLocal', ssot);
 
           upsert();
+          notification.open({
+            message: 'Successfully saved to cloud',
+            icon: (
+              <CloudUploadOutlined
+                style={{ color: corporateDesign.colorSuccessNotificationIcon }}
+              />
+            ),
+            style: {
+              backgroundColor:
+                corporateDesign.colorSuccessNotificationBackground,
+            },
+          });
         });
       })
       .catch((err) => console.error(err));

--- a/client/src/components/content/ModelerSidebar/PropertiesPanel/PropertiesPanelComponents/PPParameterInput.jsx
+++ b/client/src/components/content/ModelerSidebar/PropertiesPanel/PropertiesPanelComponents/PPParameterInput.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Input, Tooltip, Checkbox } from 'antd';
+import { Input, Tooltip, Checkbox, Typography } from 'antd';
 import { InfoCircleOutlined } from '@ant-design/icons';
 import PropTypes from 'prop-types';
 import corporateDesign from '../../../../../layout/corporateDesign';
@@ -8,6 +8,8 @@ import {
   parameterPropertyStatus,
   setPropertyForParameter,
 } from '../../../../../utils/attributeAndParamUtils';
+
+const { Text } = Typography;
 
 /**
  * @description Renders a parameter input field for a given variable
@@ -57,6 +59,7 @@ const PPParameterInput = ({
   };
   return (
     <>
+      <Text className={styles[`label-on-dark-background`]}>{variableName}</Text>
       <Input
         placeholder={variableName}
         defaultValue={value}

--- a/client/src/components/content/ModelerSidebar/PropertiesPanel/PropertiesPanelSections/PPIdSection.jsx
+++ b/client/src/components/content/ModelerSidebar/PropertiesPanel/PropertiesPanelSections/PPIdSection.jsx
@@ -10,10 +10,14 @@ const { Text } = Typography;
  * @component
  */
 const PPIdSection = (element) => (
-    <Space direction='horizontal' style={{ width: '100%' }}>
-        <Text className={styles[`label-on-dark-background`]}>ID: </Text>
-        <Text className={styles[`label-on-dark-background`]}>{element.element.id}</Text>
-    </Space>
+  <Space direction='horizontal' style={{ width: '100%' }}>
+    <Text className={styles[`label-on-dark-background`]} strong>
+      ID:{' '}
+    </Text>
+    <Text className={styles[`label-on-dark-background`]}>
+      {element.element.id}
+    </Text>
+  </Space>
 );
 
 export default PPIdSection;

--- a/client/src/components/content/ModelerSidebar/PropertiesPanel/PropertiesPanelSections/PPNameSection.jsx
+++ b/client/src/components/content/ModelerSidebar/PropertiesPanel/PropertiesPanelSections/PPNameSection.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types'
+import PropTypes from 'prop-types';
 import { Input, Typography, Tooltip } from 'antd';
 import { InfoCircleOutlined } from '@ant-design/icons';
 import corporateDesign from '../../../../../layout/corporateDesign';
@@ -13,24 +13,28 @@ const { Text } = Typography;
  * @component
  */
 const PPNameSection = ({ element, nameChanged }) => (
-    <>
-        <Text className={styles[`label-on-dark-background`]}>Name:</Text>
-        <Input
-            placeholder='name'
-            suffix={
-                <Tooltip title='the name of your task, gateway or event'>
-                    <InfoCircleOutlined style={{ color: corporateDesign.colorPrimaryInverted }} />
-                </Tooltip>
-            }
-            value={element.businessObject.name || ''}
-            onChange={nameChanged}
-        />
-    </>
+  <>
+    <Text className={styles[`label-on-dark-background`]} strong>
+      Name:
+    </Text>
+    <Input
+      placeholder='name'
+      suffix={
+        <Tooltip title='the name of your task, gateway or event'>
+          <InfoCircleOutlined
+            style={{ color: corporateDesign.colorPrimaryInverted }}
+          />
+        </Tooltip>
+      }
+      value={element.businessObject.name || ''}
+      onChange={nameChanged}
+    />
+  </>
 );
 
 PPNameSection.propTypes = {
-    element: PropTypes.objectOf(PropTypes.shape).isRequired,
-    nameChanged: PropTypes.func.isRequired,
+  element: PropTypes.objectOf(PropTypes.shape).isRequired,
+  nameChanged: PropTypes.func.isRequired,
 };
 
 export default PPNameSection;

--- a/client/src/components/content/ModelerSidebar/PropertiesPanel/PropertiesPanelSections/PPParameterSection.jsx
+++ b/client/src/components/content/ModelerSidebar/PropertiesPanel/PropertiesPanelSections/PPParameterSection.jsx
@@ -18,7 +18,9 @@ const PPParameterSection = ({
   robotId,
 }) => (
   <>
-    <Text className={styles[`label-on-dark-background`]}>Parameter:</Text>
+    <Text className={styles[`label-on-dark-background`]} strong>
+      Parameter:
+    </Text>
 
     <Space direction='vertical' style={{ width: '100%' }}>
       {variableList.map((singleInput) => (

--- a/client/src/components/content/ModelerSidebar/PropertiesPanel/PropertiesPanelSections/PPRpaSection.jsx
+++ b/client/src/components/content/ModelerSidebar/PropertiesPanel/PropertiesPanelSections/PPRpaSection.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Typography, Space } from 'antd';
-import PropTypes from 'prop-types'
+import PropTypes from 'prop-types';
 import PropertiesPanelApplicationDropdown from '../PropertiesPanelComponents/PPApplicationDropdown';
 import PropertiesPanelTaskDropdown from '../PropertiesPanelComponents/PPTaskDropdown';
 import styles from '../../ModelerSidebar.module.css';
@@ -13,36 +13,40 @@ const { Text } = Typography;
  * @component
  */
 const PPRpaSection = ({
-    applicationSelectionUpdated,
-    tasksForSelectedApplication,
-    taskSelectionUpdated,
-    disableTaskSelection,
-    selectedActivity,
+  applicationSelectionUpdated,
+  tasksForSelectedApplication,
+  taskSelectionUpdated,
+  disableTaskSelection,
+  selectedActivity,
 }) => (
-    <>
-        <Text className={styles[`label-on-dark-background`]}>Actions: </Text>
-        <Space direction='vertical' style={{ width: '100%' }}>
-            <PropertiesPanelApplicationDropdown
-                onApplicationSelection={applicationSelectionUpdated}
-                applications={JSON.parse(sessionStorage.getItem('availableApplications'))}
-                selectedActivity={selectedActivity}
-            />
-            <PropertiesPanelTaskDropdown
-                listOfTasks={tasksForSelectedApplication}
-                onTaskSelection={taskSelectionUpdated}
-                disabled={disableTaskSelection}
-                selectedActivity={selectedActivity}
-            />
-        </Space>
-    </>
+  <>
+    <Text className={styles[`label-on-dark-background`]} strong>
+      Actions:{' '}
+    </Text>
+    <Space direction='vertical' style={{ width: '100%' }}>
+      <PropertiesPanelApplicationDropdown
+        onApplicationSelection={applicationSelectionUpdated}
+        applications={JSON.parse(
+          sessionStorage.getItem('availableApplications')
+        )}
+        selectedActivity={selectedActivity}
+      />
+      <PropertiesPanelTaskDropdown
+        listOfTasks={tasksForSelectedApplication}
+        onTaskSelection={taskSelectionUpdated}
+        disabled={disableTaskSelection}
+        selectedActivity={selectedActivity}
+      />
+    </Space>
+  </>
 );
 
 PPRpaSection.propTypes = {
-    applicationSelectionUpdated: PropTypes.func.isRequired,
-    selectedActivity: PropTypes.string.isRequired,
-    tasksForSelectedApplication: PropTypes.arrayOf(PropTypes.shape).isRequired,
-    taskSelectionUpdated: PropTypes.func.isRequired,
-    disableTaskSelection: PropTypes.bool.isRequired
+  applicationSelectionUpdated: PropTypes.func.isRequired,
+  selectedActivity: PropTypes.string.isRequired,
+  tasksForSelectedApplication: PropTypes.arrayOf(PropTypes.shape).isRequired,
+  taskSelectionUpdated: PropTypes.func.isRequired,
+  disableTaskSelection: PropTypes.bool.isRequired,
 };
 
 export default PPRpaSection;

--- a/client/src/layout/corporateDesign.css
+++ b/client/src/layout/corporateDesign.css
@@ -9,4 +9,6 @@
   --colorBackground2: #ffffff;
   --colorBackgroundText: #1d1d1f;
   --colorBackgroundCta: #ff6b00;
+  --colorSuccessNotificationBackground: #ebffeb;
+  --colorSuccessNotificationIcon: #08c908;
 }

--- a/client/src/layout/corporateDesign.js
+++ b/client/src/layout/corporateDesign.js
@@ -8,6 +8,8 @@ const colorBackground = '#EFEFEF';
 const colorBackground2 = '#FFFFFF';
 const colorBackgroundText = '#1D1D1F';
 const colorBackgroundCta = '#FF6B00';
+const colorSuccessNotificationBackground = '#ebffeb';
+const colorSuccessNotificationIcon = '#08c908';
 
 module.exports = {
   colorPrimary,
@@ -18,4 +20,6 @@ module.exports = {
   colorBackground2,
   colorBackgroundText,
   colorBackgroundCta,
+  colorSuccessNotificationBackground,
+  colorSuccessNotificationIcon,
 };


### PR DESCRIPTION
closes #232 
closes #233 

## Changes
We now give feedback upon clicking the save to cloud button, as well as displaying the mane of the parameter above the input field. To highlight the text, sidebar section headlines are now bold text.

The new sidebar design:
<img width="308" alt="Screenshot 2021-04-14 at 19 15 38" src="https://user-images.githubusercontent.com/44369294/114751957-17625280-9d56-11eb-8cdb-2aa9b53c53d7.png">


The notification confirming the cloud upsert:
https://user-images.githubusercontent.com/44369294/114752173-4d9fd200-9d56-11eb-9b6a-56ded1ef5a59.mov

## Checklist before merge

**Developer's responsibilities**
* [ ] **Assign** one or two developers
* [ ] **Change code** if reviewer(s) has/have requested it
* [ ] **Pull request build** has passed
* [ ] **tested locally** (in at least chrome & firefox if frontend)
* [ ] updated the **documentation**
* [ ] added **tests** where necessary
