### PR TITLE
refactor socket methods into separate files

### DIFF
--- a/client/src/api/socketHandler/socketEmitter.js
+++ b/client/src/api/socketHandler/socketEmitter.js
@@ -1,0 +1,24 @@
+/**
+ * @category Client
+ * @module
+ */
+import socket from '../../utils/socket/socketConnections';
+
+/**
+ * @description Emits a new event that a user joined its room
+ * @param {String} userId Id of the user for which room should be joined
+ */
+const joinRoomForUser = (userId) => {
+  socket.emit('joinUserRoom', userId);
+};
+
+/**
+ * @description Emits a new event that a user wants to enqueue a robot instace for execution
+ * @param {String} userId Id of the user for which to start a robot for
+ * @param {String} robotId Id of the robot which should be started
+ */
+const startRobotForUser = (userId, robotId) => {
+  socket.emit('robotExecutionJobs', { robotId, userId });
+};
+
+export { joinRoomForUser, startRobotForUser };

--- a/client/src/api/socketHandler/socketListeners.js
+++ b/client/src/api/socketHandler/socketListeners.js
@@ -1,0 +1,28 @@
+/**
+ * @category Client
+ * @module
+ */
+import socket from '../../utils/socket/socketConnections';
+
+/**
+ * @description Register listener on successful connection to a user room
+ */
+const successRoomConnection = () => {
+  socket.on('successUserRoomConnection', (message) => message);
+};
+
+/**
+ * @description Register listener on faulty connection to a user room
+ */
+const errorRoomConnection = () => {
+  socket.on('errorUserRoomConnection', (message) => message);
+};
+
+/**
+ * @description Register listener on when a new client joins the room
+ */
+const newClientJoined = () => {
+  socket.on('newClientJoinedUserRoom', (message) => message);
+};
+
+export { successRoomConnection, errorRoomConnection, newClientJoined };

--- a/client/src/components/content/RobotContainer/RobotContainer.jsx
+++ b/client/src/components/content/RobotContainer/RobotContainer.jsx
@@ -4,7 +4,7 @@ import { Col, Row, Typography } from 'antd';
 import { PlayCircleOutlined, EditOutlined } from '@ant-design/icons';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import socket from '../../../utils/socket/socketConnections';
+import { startRobotForUser } from '../../../api/socketHandler/socketEmitter';
 import styles from './RobotContainer.module.css';
 import { changeSsotName } from '../../../api/ssotRetrieval';
 import { isRobotExecutable } from '../../../utils/robotExecution';
@@ -26,7 +26,7 @@ const RobotContainer = (props) => {
   const startRobot = async () => {
     const robotIsExecutable = await isRobotExecutable(robotId);
     if (robotIsExecutable) {
-      socket.emit('robotExecutionJobs', { robotId, userId });
+      startRobotForUser(userId, robotId);
     } else {
       alert('Your Bot is not fully configured and can not be executed!');
     }

--- a/client/src/components/pages/RobotOverview/RobotOverview.jsx
+++ b/client/src/components/pages/RobotOverview/RobotOverview.jsx
@@ -2,7 +2,12 @@ import React, { useState, useEffect } from 'react';
 import { Layout, Input, Space, Row, Select } from 'antd';
 import HeaderNavbar from '../../content/HeaderNavbar/HeaderNavbar';
 import RobotContainer from '../../content/RobotContainer/RobotContainer';
-import socket from '../../../utils/socket/socketConnections';
+import { joinRoomForUser } from '../../../api/socketHandler/socketEmitter';
+import {
+  successRoomConnection,
+  errorRoomConnection,
+  newClientJoined,
+} from '../../../api/socketHandler/socketListeners';
 import CreateRobotContainer from '../../content/RobotContainer/CreateRobotContainer';
 import initSessionStorage from '../../../utils/sessionStorage';
 import { fetchSsotsForUser, createNewRobot } from '../../../api/ssotRetrieval';
@@ -48,10 +53,10 @@ const RobotOverview = () => {
    * @description The socket will join a new user room whenever the userId state changes
    */
   useEffect(() => {
-    socket.emit('joinUserRoom', userId);
-    socket.on('successUserRoomConnection', (message) => message);
-    socket.on('errorUserRoomConnection', (message) => message);
-    socket.on('newClientJoinedUserRoom', (message) => message);
+    joinRoomForUser(userId);
+    successRoomConnection();
+    errorRoomConnection();
+    newClientJoined();
   }, [userId]);
 
   /**


### PR DESCRIPTION
closes #224 

## Changes
Refactor socket methods into separate files. There now is a folder in the api directory, which includes two files, which can be used for listeners and emitters for the sockets. Those methods can now be used by simply calling the methods themselves.


## Checklist before merge

**Developer's responsibilities**
* [ ] **Assign** one or two developers
* [ ] **Change code** if reviewer(s) has/have requested it
* [ ] **Pull request build** has passed
* [ ] **tested locally** (in at least chrome & firefox if frontend)
* [ ] updated the **documentation**
* [ ] added **tests** where necessary
