### PR TITLE
handle robot execution error

### DIFF
--- a/client/src/api/socketHandler/socketEmitter.js
+++ b/client/src/api/socketHandler/socketEmitter.js
@@ -9,7 +9,7 @@ import socket from '../../utils/socket/socketConnections';
  * @param {String} userId Id of the user for which room should be joined
  */
 const joinRoomForUser = (userId) => {
-  socket.emit('joinUserRoom', userId);
+  socket.emit('joinUserRoom', userId, 'webApplication');
 };
 
 /**

--- a/server/socket/socketHelperFunctions.js
+++ b/server/socket/socketHelperFunctions.js
@@ -15,8 +15,10 @@ mongoose.set('useFindAndModify', false);
 exports.getRobotCode = async (robotId) => {
   try {
     const ssot = await mongoose.model('SSoT').findById(robotId).exec();
-    const robotCode = ssotToRobotParser.parseSsotToRobotCode(ssot);
-    return robotCode;
+    if (ssot) {
+      return ssotToRobotParser.parseSsotToRobotCode(ssot);
+    }
+    return undefined;
   } catch (err) {
     return console.error(err);
   }

--- a/server/socket/socketManager.js
+++ b/server/socket/socketManager.js
@@ -5,7 +5,7 @@ exports.socketManager = (io, socket) => {
 
   /*  When a client wants to join a room we check if the roomId (userId) matches any of the userIds in the database.
   Once connected we check for waiting jobs and if available send them to the client to execute */
-  socket.on('joinUserRoom', (userId) => {
+  socket.on('joinUserRoom', (userId, clientType) => {
     socketHelperFunctions.getAllUserIds().then((users) => {
       if (users.includes(userId)) {
         socket.join(userId);
@@ -17,24 +17,36 @@ exports.socketManager = (io, socket) => {
           'newClientJoinedUserRoom',
           `New user has been connected to the room`
         );
-        socketHelperFunctions
-          .getAllWaitingJobsForUser(userId)
-          .then((jobList) => {
-            if (jobList.length > 0) {
-              jobList.forEach((job) => {
-                const { id, robot_id } = job;
-                socketHelperFunctions
-                  .getRobotCode(robot_id)
-                  .then((robotCode) => {
-                    socketHelperFunctions.updateRobotJobStatus(id, 'executing');
-                    io.to(userId).emit('robotExecution', {
-                      robotCode,
-                      jobId: id,
+        if (clientType !== 'webApplication') {
+          socketHelperFunctions
+            .getAllWaitingJobsForUser(userId)
+            .then((jobList) => {
+              if (jobList.length > 0) {
+                jobList.forEach((job) => {
+                  const { id, robot_id } = job;
+                  socketHelperFunctions
+                    .getRobotCode(robot_id)
+                    .then((robotCode) => {
+                      if (robotCode) {
+                        socketHelperFunctions.updateRobotJobStatus(
+                          id,
+                          'executing'
+                        );
+                        io.to(userId).emit('robotExecution', {
+                          robotCode,
+                          jobId: id,
+                        });
+                      } else {
+                        socketHelperFunctions.updateRobotJobStatus(
+                          id,
+                          'failed'
+                        );
+                      }
                     });
-                  });
-              });
-            }
-          });
+                });
+              }
+            });
+        }
 
         // eslint-disable-next-line no-else-return
       } else {


### PR DESCRIPTION

## Changes
- only parse code when a non-webApplication client joins the user room on the socket
- in case no ssot could be found for a job, this jobs status is set to 'failed'

Previously we had an issue where every client connecting to the socket connection/room would trigger a parsing of all robots. This caught my attention when there was a bug causing the backend to fail after a robot was started (had the status 'waiting' in the database), but the robot/ssot was deleted. Then the Parser would crash because it would try to access an ssot which is not available, causing the server to crash.


## Checklist before merge

**Developer's responsibilities**
* [ ] **Assign** one or two developers
* [ ] **Change code** if reviewer(s) has/have requested it
* [ ] **Pull request build** has passed
* [ ] **tested locally** (in at least chrome & firefox if frontend)
* [ ] updated the **documentation**
* [ ] added **tests** where necessary
