### PR TITLE
59 hint text for param inputs

### DIFF
--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -5,7 +5,6 @@ import Home from './pages/Home/Home';
 import Error from './pages/Error/Error';
 import RobotFile from './pages/RobotFile/RobotFile';
 import RobotOverview from './pages/RobotOverview/RobotOverview';
-import './App.css';
 
 /**
  * @description route component of the application

--- a/client/src/components/content/ModelerSidebar/ModelerSidebar.jsx
+++ b/client/src/components/content/ModelerSidebar/ModelerSidebar.jsx
@@ -221,8 +221,8 @@ const ModelerSidebar = ({ modeler, robotId }) => {
    * the values in the ssot
    * @param {Object} value new value of input field
    */
-  const handleInputParameterChange = (value) => {
-    setSingleParameter(elementState.currentElement.id, value);
+  const handleInputParameterChange = (value, paramName) => {
+    setSingleParameter(elementState.currentElement.id, value, paramName);
   };
 
   /**

--- a/client/src/components/content/ModelerSidebar/ModelerSidebar.module.css
+++ b/client/src/components/content/ModelerSidebar/ModelerSidebar.module.css
@@ -2,6 +2,10 @@
   color: var(--colorPrimaryInvertedText) !important;
 }
 
+.requiredStar {
+  color : var(--colorBackgroundCta) !important;
+}
+
 .title {
   margin-bottom: 0rem !important;
   color: var(--colorPrimaryInvertedText) !important;

--- a/client/src/components/content/ModelerSidebar/PropertiesPanel/PropertiesPanelComponents/PPParameterInput.jsx
+++ b/client/src/components/content/ModelerSidebar/PropertiesPanel/PropertiesPanelComponents/PPParameterInput.jsx
@@ -57,7 +57,7 @@ const PPParameterInput = ({
    * @param {Object} event from the input field
    * @param {String} parameterName Name of the currently handled parameter
    */
-  const changeParamterValue = (event, parameterName) => {
+  const changeParameterValue = (event, parameterName) => {
     setPropertyForParameter(
       selectedActivity,
       parameterName,
@@ -105,8 +105,8 @@ const PPParameterInput = ({
         placeholder={returnPlaceholderValue()}
         defaultValue={value}
         value={userInputRequired ? '' : parameterValue}
-        onChange={(event) => changeParamterValue(event, variableName)}
-        onPressEnter={onValueChange}
+        onChange={(event) => changeParameterValue(event, variableName)}
+        onPressEnter={(event) => onValueChange(event, variableName)}
         suffix={
           <Tooltip title={infoText}>
             <InfoCircleOutlined />

--- a/client/src/components/content/ModelerSidebar/PropertiesPanel/PropertiesPanelComponents/PPParameterInput.jsx
+++ b/client/src/components/content/ModelerSidebar/PropertiesPanel/PropertiesPanelComponents/PPParameterInput.jsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
-import { Input, Tooltip, Checkbox, Row, Typography, Form, Button } from 'antd';
-import { InfoCircleOutlined, LockOutlined, UnlockOutlined, ExclamationCircleOutlined } from '@ant-design/icons';
+import { Input, Tooltip, Typography } from 'antd';
+import { InfoCircleOutlined, LockOutlined, UnlockOutlined } from '@ant-design/icons';
 import PropTypes from 'prop-types';
-import corporateDesign from '../../../../../layout/corporateDesign';
 import styles from '../../ModelerSidebar.module.css';
 import {
   parameterPropertyStatus,
@@ -10,7 +9,6 @@ import {
 } from '../../../../../utils/attributeAndParamUtils';
 
 const { Text } = Typography;
-const { Search } = Input;
 
 /**
  * @description Renders a parameter input field for a given variable
@@ -40,7 +38,11 @@ const PPParameterInput = ({
     parameterPropertyStatus(robotId, selectedActivity, variableName, 'value')
   );
 
-  const changeUserInputRequirement = (event, parameterName) => {
+  /**
+   * @description changes the state for "userInputRequired" and also the parameter value 
+   * @param {String} parameterName Name of the currently handled parameter
+   */
+  const changeUserInputRequirement = (parameterName) => {
     setPropertyForParameter(
       selectedActivity,
       parameterName,
@@ -48,9 +50,13 @@ const PPParameterInput = ({
       !userInputRequired
     );
     setUserInputRequired(!userInputRequired);
-    console.log(userInputRequired)
   };
 
+  /**
+   * @description changes the parameter value
+   * @param {Object} event from the input field
+   * @param {String} parameterName Name of the currently handled parameter
+   */
   const changeParamterValue = (event, parameterName) => {
     setPropertyForParameter(
       selectedActivity,
@@ -61,41 +67,42 @@ const PPParameterInput = ({
     setParameterValue(event.target.value);
   };
 
-  const lockInputButton = () => (
-    <LockOutlined onClick={(event) => {
-      console.log('OnClick1');
-      changeUserInputRequirement(event, variableName)
-    }} />
-    // <Checkbox onChange={buttonClick} />
-    /* <Link onClick={buttonClick} >
-      <Text type="primary">
-        Disable
-    </Text>
-    </Link> */
+  /**
+   * @description returns the Loch/Unlock-Icon on whether the Input-field is locked or unlocked
+   * @returns the corresponding icon
+   */
+  const returnLockIcon = () => {
+    if (userInputRequired) {
+      return (
+        <LockOutlined onClick={(event) => {
+          changeUserInputRequirement(event, variableName)
+        }} />
+      )
+    }
+    return (
+      <UnlockOutlined onClick={(event) => {
+        changeUserInputRequirement(event, variableName)
+      }} />
+    )
+  }
 
-    /*     <Checkbox
-          onChange={(event) => changeUserInputRequirement(event, variableName)}
-          checked={userInputRequired}
-          className={styles[`label-on-dark-background`]}
-        >
-          User Input required
-        </Checkbox> */
-  )
+  /**
+   * @returns the input value depending on whether the field is locked or unlocked
+   */
+  const returnPlaceholderValue = () => (
+    userInputRequired ? 'Will be specified at bot start' : 'Please type in value')
 
   return (
     <>
-      <Row>
-        <Text className={styles[`label-on-dark-background`]}>{variableName}</Text>
-        {isRequired && (
-          <Tooltip title='HintText' className={styles.requiredStar}>
-            &nbsp;*
-          </Tooltip>
-        )
-        }
-      </Row>
+      <Text className={styles[`label-on-dark-background`]}>{variableName}</Text>
+      {isRequired && (
+        <Tooltip title='This field is required' className={styles.requiredStar}>
+          &nbsp;*
+        </Tooltip>
+      )}
 
       <Input
-        placeholder='Please type in value'
+        placeholder={returnPlaceholderValue()}
         defaultValue={value}
         value={userInputRequired ? '' : parameterValue}
         onChange={(event) => changeParamterValue(event, variableName)}
@@ -104,12 +111,9 @@ const PPParameterInput = ({
           <Tooltip title={infoText}>
             <InfoCircleOutlined />
           </Tooltip>}
-        addonAfter={lockInputButton()}
+        addonAfter={returnLockIcon()}
         disabled={userInputRequired}
       />
-
-
-
     </>
   );
 };

--- a/client/src/components/content/ModelerSidebar/PropertiesPanel/PropertiesPanelComponents/PPParameterInput.jsx
+++ b/client/src/components/content/ModelerSidebar/PropertiesPanel/PropertiesPanelComponents/PPParameterInput.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import { Input, Tooltip, Checkbox, Typography } from 'antd';
-import { InfoCircleOutlined } from '@ant-design/icons';
+import { Input, Tooltip, Checkbox, Row, Typography, Form, Button } from 'antd';
+import { InfoCircleOutlined, LockOutlined, UnlockOutlined, ExclamationCircleOutlined } from '@ant-design/icons';
 import PropTypes from 'prop-types';
 import corporateDesign from '../../../../../layout/corporateDesign';
 import styles from '../../ModelerSidebar.module.css';
@@ -10,6 +10,7 @@ import {
 } from '../../../../../utils/attributeAndParamUtils';
 
 const { Text } = Typography;
+const { Search } = Input;
 
 /**
  * @description Renders a parameter input field for a given variable
@@ -22,6 +23,7 @@ const PPParameterInput = ({
   isRequired,
   // eslint-disable-next-line no-unused-vars
   dataType,
+  infoText,
   value,
   robotId,
   selectedActivity,
@@ -43,9 +45,10 @@ const PPParameterInput = ({
       selectedActivity,
       parameterName,
       'requireUserInput',
-      event.target.checked
+      !userInputRequired
     );
-    setUserInputRequired(event.target.checked);
+    setUserInputRequired(!userInputRequired);
+    console.log(userInputRequired)
   };
 
   const changeParamterValue = (event, parameterName) => {
@@ -57,33 +60,56 @@ const PPParameterInput = ({
     );
     setParameterValue(event.target.value);
   };
+
+  const lockInputButton = () => (
+    <LockOutlined onClick={(event) => {
+      console.log('OnClick1');
+      changeUserInputRequirement(event, variableName)
+    }} />
+    // <Checkbox onChange={buttonClick} />
+    /* <Link onClick={buttonClick} >
+      <Text type="primary">
+        Disable
+    </Text>
+    </Link> */
+
+    /*     <Checkbox
+          onChange={(event) => changeUserInputRequirement(event, variableName)}
+          checked={userInputRequired}
+          className={styles[`label-on-dark-background`]}
+        >
+          User Input required
+        </Checkbox> */
+  )
+
   return (
     <>
-      <Text className={styles[`label-on-dark-background`]}>{variableName}</Text>
+      <Row>
+        <Text className={styles[`label-on-dark-background`]}>{variableName}</Text>
+        {isRequired && (
+          <Tooltip title='HintText' className={styles.requiredStar}>
+            &nbsp;*
+          </Tooltip>
+        )
+        }
+      </Row>
+
       <Input
-        placeholder={variableName}
+        placeholder='Please type in value'
         defaultValue={value}
         value={userInputRequired ? '' : parameterValue}
         onChange={(event) => changeParamterValue(event, variableName)}
         onPressEnter={onValueChange}
         suffix={
-          isRequired && (
-            <Tooltip title='This field is required for the task to work'>
-              <InfoCircleOutlined
-                style={{ color: corporateDesign.colorBackgroundCta }}
-              />
-            </Tooltip>
-          )
-        }
+          <Tooltip title={infoText}>
+            <InfoCircleOutlined />
+          </Tooltip>}
+        addonAfter={lockInputButton()}
         disabled={userInputRequired}
       />
-      <Checkbox
-        onChange={(event) => changeUserInputRequirement(event, variableName)}
-        checked={userInputRequired}
-        className={styles[`label-on-dark-background`]}
-      >
-        User Input required
-      </Checkbox>
+
+
+
     </>
   );
 };
@@ -96,6 +122,7 @@ PPParameterInput.propTypes = {
   value: PropTypes.string.isRequired,
   robotId: PropTypes.string.isRequired,
   selectedActivity: PropTypes.string.isRequired,
+  infoText: PropTypes.string.isRequired,
 };
 
 export default PPParameterInput;

--- a/client/src/components/content/ModelerSidebar/PropertiesPanel/PropertiesPanelSections/PPParameterSection.jsx
+++ b/client/src/components/content/ModelerSidebar/PropertiesPanel/PropertiesPanelSections/PPParameterSection.jsx
@@ -31,6 +31,7 @@ const PPParameterSection = ({
             isRequired={singleInput.isRequired}
             dataType={singleInput.type}
             value={singleInput.value}
+            infoText={singleInput.infoText}
             robotId={robotId}
             selectedActivity={selectedActivity}
           />

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import 'antd/dist/antd.css';
 import './index.css';
-import './components/App.css';
 import App from './components/App';
 // import reportWebVitals from './reportWebVitals';
 

--- a/client/src/layout/customizedTheme.js
+++ b/client/src/layout/customizedTheme.js
@@ -10,12 +10,16 @@ const customizedTheme = {
   '@body-background': corporateDesign.colorBackground,
   '@layout-body-background': corporateDesign.colorBackground,
   '@border-radius-base': '5px',
+  '@label-color': corporateDesign.colorPrimaryInvertedText,
+
   // text
   '@heading-color': corporateDesign.colorBackgroundText,
   '@text-color': corporateDesign.colorBackgroundText,
   '@text-color-dark': corporateDesign.colorPrimaryInvertedText,
   // button
   '@btn-primary-bg': corporateDesign.colorBackgroundCta,
+  // input
+  '@input-color': corporateDesign.colorBackgroundText,
   // sider
   '@layout-sider-background': corporateDesign.colorPrimaryInverted2,
   // component

--- a/client/src/utils/attributeAndParamUtils.js
+++ b/client/src/utils/attributeAndParamUtils.js
@@ -50,7 +50,7 @@ const resetRpaApplication = (robotId, activityId, newApplication) => {
   } else {
     matchingActivity = {
       activityId,
-      robotId: robotId,
+      robotId,
       rpaApplication: newApplication,
     };
   }
@@ -88,7 +88,7 @@ const setRpaTask = (robotId, activityId, application, newTask) => {
   } else {
     matchingActivity = {
       activityId,
-      robotId: robotId,
+      robotId,
       rpaApplication: application,
       rpaTask: newTask,
     };
@@ -145,7 +145,7 @@ const getRpaTask = (activityId) => {
 /**
  * @description Will retrieve the value of the input variables name from either session storage,
  * or create a new one and will save it in local session storage.
- * If an existing prameter object has been found there will be a check happening, if the signature matches
+ * If an existing parameter object has been found there will be a check happening, if the signature matches
  * the one specified for that activities task and application. If not, then something must have been out of sync
  * and a new object will be created and saved to sessionStorage.
  * @param {String} robotId Id of the robot/ssot for which to retrieve the value
@@ -239,7 +239,7 @@ const getParameterObject = (robotId, activityId) => {
           ? `${activityId}_output`
           : undefined,
       rpaParameters,
-      robotId: robotId,
+      robotId,
     };
 
     localParameterStorage.push(matchingParameterObject);
@@ -256,7 +256,7 @@ const getParameterObject = (robotId, activityId) => {
  * @param {String} activityId Id of the activity for which to change the value for
  * @param {Object} value The value object returned by the dropdown selection
  */
-const setSingleParameter = (activityId, value) => {
+const setSingleParameter = (activityId, value, paramName) => {
   const localParameterStorage = JSON.parse(
     sessionStorage.getItem('parameterLocalStorage')
   );
@@ -268,15 +268,15 @@ const setSingleParameter = (activityId, value) => {
   );
 
   const matchingSingleParameter = matchingParameterObject.rpaParameters.find(
-    (element) => element.name === value.target.placeholder
+    (element) => element.name === paramName
   );
   const singleParametersWithoutMatch = matchingParameterObject.rpaParameters.filter(
-    (element) => element.name !== value.target.placeholder
+    (element) => element.name !== paramName
   );
 
-  const editedPrameter = matchingSingleParameter;
-  editedPrameter.value = value.target.value;
-  singleParametersWithoutMatch.push(editedPrameter);
+  const editedParameter = matchingSingleParameter;
+  editedParameter.value = value.target.value;
+  singleParametersWithoutMatch.push(editedParameter);
 
   const editedParameterObject = matchingParameterObject;
   editedParameterObject.rpaParameters = singleParametersWithoutMatch;


### PR DESCRIPTION
closes #59 
## Changes
**What does this PR change? What was the problem? What is the solution?**
With this pull request, we solve the problem that the info texts for each parameter cannot be displayed. Also, the design of the sidebar has been changed, so it takes up less space. The "Required field" is now displayed as a star (in CTA color).

*Conditions of satisfaction:*
- [x] The entire backend should have appropriate hint texts for all input fields (variables).
- [x] Should introduce a new way to display a user, which fields are required
- [x] Should use the tooltip info icon in the input field to display the information about the parameter


https://user-images.githubusercontent.com/36270527/115760873-fdea8780-a3a1-11eb-849b-322a3ae26bc1.mp4