### PR TITLE
Hotfix no params in robot code

### DIFF
--- a/client/src/utils/parser/robotCodeToSsotParsing/robotCodeToSsotParsing.js
+++ b/client/src/utils/parser/robotCodeToSsotParsing/robotCodeToSsotParsing.js
@@ -113,14 +113,15 @@ const getOutputName = (currentLine) => {
 };
 
 /**
- * @description retrieves the rpa task from the current code line
+ * @description retrieves the rpa task from the current code line; if there are no params, 
+ * the indexOfFirstSplitPlaceholder returns -1 and therefore the function returns the whole line
  * @param {String} currentLine current line of RPAf code
  * @param {String} splitPlaceholder placeholder to split the string
  * @returns rpaTask as string
  */
 const getRpaTask = (currentLine, splitPlaceholder) => {
   const indexOfFirstSplitPlaceholder = currentLine.indexOf(splitPlaceholder);
-  return currentLine.slice(0, indexOfFirstSplitPlaceholder);
+  return (indexOfFirstSplitPlaceholder === -1 ? currentLine : currentLine.slice(0, indexOfFirstSplitPlaceholder));
 };
 
 /**

--- a/client/src/utils/parser/robotCodeToSsotParsing/robotCodeToSsotParsing.js
+++ b/client/src/utils/parser/robotCodeToSsotParsing/robotCodeToSsotParsing.js
@@ -113,7 +113,7 @@ const getOutputName = (currentLine) => {
 };
 
 /**
- * @description retrieves the rpa task from the current code line; if there are no params, 
+ * @description retrieves the rpa task from the current code line; if there are no parameters, 
  * the indexOfFirstSplitPlaceholder returns -1 and therefore the function returns the whole line
  * @param {String} currentLine current line of RPAf code
  * @param {String} splitPlaceholder placeholder to split the string


### PR DESCRIPTION
The problem was that if an RPA task does not have a single parameter, a fatal parsing error occurs. This led to a crash of the application. This error has now been fixed.

The error occurred in combination with the "save excel" Task
<img width="392" alt="image" src="https://user-images.githubusercontent.com/36270527/116778073-13ca0d80-aa70-11eb-9a9f-7fb8fdc576a8.png">
