### PR TITLE
fix link bug

### DIFF
--- a/client/src/components/content/HeaderNavbar/HeaderNavbar.jsx
+++ b/client/src/components/content/HeaderNavbar/HeaderNavbar.jsx
@@ -71,7 +71,6 @@ const HeaderNavbar = (props) => {
         {onRobotInteraction && (
           <Menu.Item key={robotInteractionPageKey}>
             Robot Interaction Cockpit
-            <Link to='/robotfile' />
           </Menu.Item>
         )}
       </Menu>


### PR DESCRIPTION
With this pull request we fix the bug that when clicking on "Robot Interaction Cockpit" in the HeaderNavbar a wrong redirect is called. This could be easily fixed by deleting the link. I also checked all links in the navbar again. There are no other errors.

https://user-images.githubusercontent.com/36270527/117994993-406c0800-b341-11eb-8e2b-a9424f7debbe.mov

closes #288 